### PR TITLE
fix typo that caused a fatal error

### DIFF
--- a/fewer-tags.php
+++ b/fewer-tags.php
@@ -113,7 +113,7 @@ class JoostFewerTags {
 	public function filter_get_the_tags( $tags ) {
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $key => $tag ) {
-				if ( $tag->count < $$this->min_posts_count ) {
+				if ( $tag->count < $this->min_posts_count ) {
 					unset( $tags[ $key ] );
 				}
 			}


### PR DESCRIPTION
Fix a fatal error that is the cause of issue https://github.com/jdevalk/fewer-tags/issues/1

Uncaught Error: Object of class JoostFewerTags could not be converted to string in wp-content/plugins/fewer-tags/fewer-tags.php on line 116