### PR TITLE
Add the wp-version-checker workflow

### DIFF
--- a/.github/workflows/wp-version-checker.yml
+++ b/.github/workflows/wp-version-checker.yml
@@ -1,0 +1,20 @@
+name: "WordPress version checker"
+on:
+  push:
+    branches:
+      - develop
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  wordpress-version-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: WordPress version checker
+        uses: skaut/wordpress-version-checker@v2.0.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Context
Implements the [`wordpress-version-checker`](https://github.com/skaut/wordpress-version-checker) GitHub workflow

## Summary

Adds an action to create new issues when the "tested up to" version doesn't match the latest WordPress version.