### PR TITLE
Remove composer dependency for the autoloader

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,6 +5,7 @@
 # https://www.reddit.com/r/PHP/comments/2jzp6k/i_dont_need_your_tests_in_my_production
 # https://blog.madewithlove.be/post/gitattributes/
 #
+.distignore export-ignore
 /.editorconfig export-ignore
 /.eslintrc export-ignore
 /.github export-ignore
@@ -13,6 +14,9 @@
 /.phpcs.xml export-ignore
 /.phpcs.xml.dist export-ignore
 /.cache export-ignore
+composer.json export-ignore
+composer.lock export-ignore
+phpunit.xml.dist export-ignore
 /README.md export-ignore
 /tests export-ignore
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,9 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main
-      - name: Build
-        run: |
-          composer install --no-dev --no-interaction --no-progress --optimize-autoloader
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
         env:

--- a/README.md
+++ b/README.md
@@ -12,22 +12,6 @@ Tags that have fewer than the configured number of posts:
 
 This positively affects your site's SEO and also leads to less crawling, as you have fewer useless tag pages.
 
-## Installation
-
-To install, check out this repository and then run:
-
-```shell
-composer install
-```
-
-Or if you'd prefer a production build:
-
-```shell
-composer install --prefer-dist --optimize-autoloader --no-dev --no-scripts
-```
-
-The plugin currently doesn't require any JS or CSS to be built.
-
 ### Development
 
 To test the Playground specific setup in development, add the following to your `wp-config.php`:

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,6 @@
 			"email": "joost@joost.blog"
 		}
 	],
-	"autoload": {
-		"classmap": [
-			"src/"
-		]
-	},
 	"require-dev": {
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "*",

--- a/fewer-tags.php
+++ b/fewer-tags.php
@@ -22,50 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-/**
- * FewerTags Class
- */
-class FewerTags {
-
-	/**
-	 * Default value for the minimum number of posts a tag should have to not be redirected to the homepage.
-	 *
-	 * @var int
-	 */
-	public static $min_posts_count;
-
-	/**
-	 * Register plugin hooks.
-	 */
-	public function register_hooks() {
-		add_action( 'init', [ $this, 'init' ] );
-	}
-
-	/**
-	 * Initialize the plugin and register hooks.
-	 */
-	public function init() {
-		self::$min_posts_count = (int) get_option( 'joost_min_posts_count', 10 );
-
-		require plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
-
-		if ( is_admin() ) {
-			$admin = new FewerTags\Admin();
-			$admin->register_hooks();
-
-			// Detect if we're running on the playground, if so, load our playground specific class.
-			if ( defined( 'IS_PLAYGROUND_PREVIEW' ) && IS_PLAYGROUND_PREVIEW ) {
-				$playground = new FewerTags\Playground();
-				$playground->register_hooks();
-			}
-
-			return;
-		}
-		$frontend = new FewerTags\Frontend();
-		$frontend->register_hooks();
-	}
-}
-
 // Instantiate the plugin class.
-$fewer_tags = new FewerTags();
+$fewer_tags = new FewerTags\Plugin();
 $fewer_tags->register_hooks();

--- a/fewer-tags.php
+++ b/fewer-tags.php
@@ -22,6 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+define( 'FEWER_TAGS_DIR', __DIR__ );
+require_once __DIR__ . '/src/autoload.php';
+
 // Instantiate the plugin class.
 $fewer_tags = new FewerTags\Plugin();
 $fewer_tags->register_hooks();

--- a/src/autoload.php
+++ b/src/autoload.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Autoload PHP classes for the plugin.
+ *
+ * @package FewerTags
+ */
+
+spl_autoload_register(
+	function ( $class_name ) {
+		$prefix = 'FewerTags\\';
+
+		if ( 0 !== \strpos( $class_name, $prefix ) ) {
+			return;
+		}
+
+		$class_name = \str_replace( $prefix, '', $class_name );
+
+		$file = FEWER_TAGS_DIR . '/src/class-' . \str_replace( '_', '-', \strtolower( $class_name ) ) . '.php';
+
+		if ( \file_exists( $file ) ) {
+			require_once $file;
+		}
+	}
+);

--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -55,7 +55,7 @@ class Admin {
 	 * Display the setting field in the Reading settings page.
 	 */
 	public function display_setting() {
-		echo '<input name="joost_min_posts_count" id="joost_min_posts_count" type="number" min="1" value="' . esc_attr( \FewerTags::$min_posts_count ) . '" class="small-text" /> ';
+		echo '<input name="joost_min_posts_count" id="joost_min_posts_count" type="number" min="1" value="' . esc_attr( \FewerTags\Plugin::$min_posts_count ) . '" class="small-text" /> ';
 		esc_html_e( 'posts before being live on the site.', 'fewer-tags' );
 	}
 
@@ -84,7 +84,7 @@ class Admin {
 		if ( $column_name === 'active' ) {
 			$term = get_term( $tag_ID );
 			$out  = esc_html__( 'Live', 'fewer-tags' );
-			if ( $term->count < \FewerTags::$min_posts_count ) {
+			if ( $term->count < \FewerTags\Plugin::$min_posts_count ) {
 				$out = '<span title="' . esc_html__( 'Not live due to not enough posts being in this tag.', 'fewer-tags' ) . '">' . esc_html__( 'Not live', 'fewer-tags' ) . '</span>';
 			}
 		}
@@ -101,7 +101,7 @@ class Admin {
 	 * @return array Modified array of action links.
 	 */
 	public function remove_view_action( $actions, $tag ) {
-		if ( $tag->count < \FewerTags::$min_posts_count ) {
+		if ( $tag->count < \FewerTags\Plugin::$min_posts_count ) {
 			unset( $actions['view'] );
 		}
 

--- a/src/class-frontend.php
+++ b/src/class-frontend.php
@@ -29,7 +29,7 @@ class Frontend {
 	public function redirect_tag_pages() {
 		if ( is_tag() ) {
 			$tag = get_queried_object();
-			if ( $tag && $tag->count < \FewerTags::$min_posts_count ) {
+			if ( $tag && $tag->count < \FewerTags\Plugin::$min_posts_count ) {
 				wp_safe_redirect( home_url(), 301 );
 				// @codeCoverageIgnoreStart
 				exit;
@@ -56,7 +56,7 @@ class Frontend {
 
 		if ( is_array( $terms ) ) {
 			foreach ( $terms as $key => $tag ) {
-				if ( $tag->count < \FewerTags::$min_posts_count ) {
+				if ( $tag->count < \FewerTags\Plugin::$min_posts_count ) {
 					unset( $terms[ $key ] );
 				}
 			}
@@ -75,7 +75,7 @@ class Frontend {
 	public function filter_get_the_tags( $tags ) {
 		if ( is_array( $tags ) ) {
 			foreach ( $tags as $key => $tag ) {
-				if ( $tag->count < \FewerTags::$min_posts_count ) {
+				if ( $tag->count < \FewerTags\Plugin::$min_posts_count ) {
 					unset( $tags[ $key ] );
 				}
 			}
@@ -126,7 +126,7 @@ class Frontend {
 			$tag_ids,
 			function ( $tag_id ) {
 				$tag = get_term( $tag_id, 'post_tag' );
-				return ( $tag->count < \FewerTags::$min_posts_count );
+				return ( $tag->count < \FewerTags\Plugin::$min_posts_count );
 			}
 		);
 		return $filtered_tag_ids;
@@ -140,7 +140,7 @@ class Frontend {
 	 * @return array Modified array of term IDs to exclude from the sitemap.
 	 */
 	public function exclude_tags_from_yoast_sitemap( $excluded_term_ids ) {
-		if ( \FewerTags::$min_posts_count === 0 ) {
+		if ( \FewerTags\Plugin::$min_posts_count === 0 ) {
 			return $excluded_term_ids;
 		}
 
@@ -156,7 +156,7 @@ class Frontend {
 		if ( ! is_wp_error( $tags ) ) {
 			foreach ( $tags as $tag_id ) {
 				$term = get_term( $tag_id );
-				if ( $term->count < \FewerTags::$min_posts_count ) {
+				if ( $term->count < \FewerTags\Plugin::$min_posts_count ) {
 					$excluded_term_ids[] = $tag_id;
 				}
 			}

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * The main plugin class.
+ *
+ * @package FewerTags
+ */
+
+namespace FewerTags;
+
+/**
+ * FewerTags Class
+ */
+class Plugin {
+
+	/**
+	 * Default value for the minimum number of posts a tag should have to not be redirected to the homepage.
+	 *
+	 * @var int
+	 */
+	public static $min_posts_count;
+
+	/**
+	 * Register plugin hooks.
+	 */
+	public function register_hooks() {
+		add_action( 'init', [ $this, 'init' ] );
+	}
+
+	/**
+	 * Initialize the plugin and register hooks.
+	 */
+	public function init() {
+		self::$min_posts_count = (int) get_option( 'joost_min_posts_count', 10 );
+
+		if ( is_admin() ) {
+			$admin = new Admin();
+			$admin->register_hooks();
+
+			// Detect if we're running on the playground, if so, load our playground specific class.
+			if ( defined( 'IS_PLAYGROUND_PREVIEW' ) && IS_PLAYGROUND_PREVIEW ) {
+				$playground = new Playground();
+				$playground->register_hooks();
+			}
+
+			return;
+		}
+		$frontend = new Frontend();
+		$frontend->register_hooks();
+	}
+}

--- a/tests/phpunit/test-class-admin.php
+++ b/tests/phpunit/test-class-admin.php
@@ -7,7 +7,7 @@
 
 namespace FewerTags\Tests;
 
-use FewerTags;
+use FewerTags\Plugin;
 use FewerTags\Admin;
 
 /**
@@ -43,7 +43,7 @@ class Admin_Test extends \WP_UnitTestCase {
 		parent::set_up_before_class();
 		self::$class_instance = new Admin();
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 
 		self::$live_tag     = wp_insert_term( 'Live tag', 'post_tag' );
 		self::$not_live_tag = wp_insert_term( 'Not alive', 'post_tag' );
@@ -116,7 +116,7 @@ class Admin_Test extends \WP_UnitTestCase {
 		$this->assertStringContainsString( 'id="joost_min_posts_count"', $output );
 		$this->assertStringContainsString( 'type="number"', $output );
 		$this->assertStringContainsString( 'min="1"', $output );
-		$this->assertStringContainsString( 'value="5"', $output ); // This is tied to the value of FewerTags::$min_posts_count.
+		$this->assertStringContainsString( 'value="5"', $output ); // This is tied to the value of Plugin::$min_posts_count.
 		$this->assertStringContainsString( 'class="small-text"', $output );
 		$this->assertStringContainsString( 'posts before being live on the site.', $output );
 	}

--- a/tests/phpunit/test-class-frontend.php
+++ b/tests/phpunit/test-class-frontend.php
@@ -7,7 +7,7 @@
 
 namespace FewerTags\Tests;
 
-use FewerTags;
+use FewerTags\Plugin;
 use FewerTags\Frontend;
 
 /**
@@ -50,7 +50,7 @@ class Frontend_Test extends \WP_UnitTestCase {
 		parent::set_up_before_class();
 		self::$class_instance = new Frontend();
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 
 		self::$live_tag     = wp_insert_term( 'Live tag', 'post_tag' );
 		self::$not_live_tag = wp_insert_term( 'Not alive', 'post_tag' );
@@ -129,7 +129,7 @@ class Frontend_Test extends \WP_UnitTestCase {
 		// Set the global $wp_query object as a tag page with fewer posts than required.
 		$GLOBALS['wp_query']->is_tag = true;
 
-		// Assuming \FewerTags::$min_posts_count > 1.
+		// Assuming \FewerTags\Plugin::$min_posts_count > 1.
 		$GLOBALS['wp_query']->queried_object = (object) [ 'count' => 1 ];
 
 		try {
@@ -145,7 +145,7 @@ class Frontend_Test extends \WP_UnitTestCase {
 		// Set the global $wp_query object as a tag page with fewer posts than required.
 		$GLOBALS['wp_query']->is_tag = true;
 
-		// Assuming \FewerTags::$min_posts_count > 1.
+		// Assuming \FewerTags\Plugin::$min_posts_count > 1.
 		$GLOBALS['wp_query']->queried_object = (object) [ 'count' => 11 ];
 
 		self::$class_instance->redirect_tag_pages();
@@ -165,13 +165,13 @@ class Frontend_Test extends \WP_UnitTestCase {
 		$terms = self::$class_instance->filter_get_the_terms( [ $live_tag, $not_live_tag ], self::$test_post, 'post_tag' );
 		$this->assertSame( [ $live_tag ], $terms );
 
-		FewerTags::$min_posts_count = 1;
+		Plugin::$min_posts_count = 1;
 
 		// Test when count is 1, and the post has both the live and the not live tag (which has 1 post in it, so _is_ live now).
 		$terms = self::$class_instance->filter_get_the_terms( [ $live_tag, $not_live_tag ], self::$test_post, 'post_tag' );
 		$this->assertSame( [ $live_tag, $not_live_tag ], $terms );
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 
 		// Test with a taxonomy other than post_tag.
 		$terms = self::$class_instance->filter_get_the_terms( [ $live_tag, $not_live_tag ], self::$test_post, 'category' );
@@ -190,12 +190,12 @@ class Frontend_Test extends \WP_UnitTestCase {
 		$tags = self::$class_instance->filter_get_the_tags( [ $live_tag, $not_live_tag ] );
 		$this->assertSame( [ $live_tag ], $tags );
 
-		FewerTags::$min_posts_count = 1;
+		Plugin::$min_posts_count = 1;
 
 		$tags = self::$class_instance->filter_get_the_tags( [ $live_tag, $not_live_tag ] );
 		$this->assertSame( [ $live_tag, $not_live_tag ], $tags );
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 	}
 
 	/**
@@ -207,18 +207,18 @@ class Frontend_Test extends \WP_UnitTestCase {
 		$term_ids = self::$class_instance->exclude_tags_from_yoast_sitemap( [] );
 		$this->assertSame( [ self::$not_live_tag['term_id'] ], $term_ids );
 
-		FewerTags::$min_posts_count = 1;
+		Plugin::$min_posts_count = 1;
 
 		$term_ids = self::$class_instance->exclude_tags_from_yoast_sitemap( [] );
 		$this->assertSame( [], $term_ids );
 
-		FewerTags::$min_posts_count = 0;
+		Plugin::$min_posts_count = 0;
 
 		// Test when count = 0 we don't do anything with the input.
 		$term_ids = self::$class_instance->exclude_tags_from_yoast_sitemap( [ 'test' ] );
 		$this->assertSame( [ 'test' ], $term_ids );
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 	}
 
 	/**
@@ -231,7 +231,7 @@ class Frontend_Test extends \WP_UnitTestCase {
 		$terms = self::$class_instance->exclude_tags_from_core_sitemap( [], 'post_tag' );
 		$this->assertSame( [ 'exclude' => [ self::$not_live_tag['term_id'] ] ], $terms );
 
-		FewerTags::$min_posts_count = 1;
+		Plugin::$min_posts_count = 1;
 
 		$terms = self::$class_instance->exclude_tags_from_core_sitemap( [], 'post_tag' );
 		$this->assertSame( [ 'exclude' => [] ], $terms );
@@ -240,6 +240,6 @@ class Frontend_Test extends \WP_UnitTestCase {
 		$terms = self::$class_instance->exclude_tags_from_core_sitemap( [], 'category' );
 		$this->assertSame( [], $terms );
 
-		FewerTags::$min_posts_count = 5;
+		Plugin::$min_posts_count = 5;
 	}
 }

--- a/tests/phpunit/test-fewer-tags.php
+++ b/tests/phpunit/test-fewer-tags.php
@@ -7,7 +7,7 @@
 
 namespace FewerTags\Tests;
 
-use FewerTags;
+use FewerTags\Plugin;
 use FewerTags\Admin;
 use FewerTags\Frontend;
 
@@ -30,13 +30,13 @@ class FewerTags_Test extends \WP_UnitTestCase {
 
 		update_option( 'joost_min_posts_count', 10 );
 
-		self::$class_instance = new FewerTags();
+		self::$class_instance = new Plugin();
 	}
 
 	/**
 	 * Tests hooks registration.
 	 *
-	 * @covers FewerTags::register_hooks
+	 * @covers FewerTags\Plugin::register_hooks
 	 */
 	public function test_register_hooks() {
 		self::$class_instance->register_hooks();
@@ -47,7 +47,7 @@ class FewerTags_Test extends \WP_UnitTestCase {
 	/**
 	 * Tests init method.
 	 *
-	 * @covers FewerTags::init
+	 * @covers FewerTags\Plugin::init
 	 */
 	public function test_init() {
 		self::$class_instance->init();
@@ -58,7 +58,7 @@ class FewerTags_Test extends \WP_UnitTestCase {
 	/**
 	 * Tests init method.
 	 *
-	 * @covers FewerTags::init
+	 * @covers FewerTags\Plugin::init
 	 */
 	public function test_init_admin() {
 		// Destroy the existing instance.
@@ -70,7 +70,7 @@ class FewerTags_Test extends \WP_UnitTestCase {
 
 		set_current_screen( 'dashboard' );
 
-		self::$class_instance = new FewerTags();
+		self::$class_instance = new Plugin();
 		self::$class_instance->init();
 
 		global $wp_filter;


### PR DESCRIPTION
## Summary

Since this is a relatively simple plugin with just a handful of classes, Composer is overkill.

This PR removes the auto-generated Composer autoloader, replacing it with a custom one.
This will remove the requirement for a build step, simplifying development and releases.

## Relevant technical choices:

* We had the `FewerTags` class in the main plugin file. I moved that to a separate file and namespace it, so it's now `FewerTags\Plugin`

## Test instructions

PHPUnit already takes care of all tests related to this change, so no additional user testing is required.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #
