### PR TITLE
Rename option

### DIFF
--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -7,6 +7,8 @@
 
 namespace FewerTags;
 
+use FewerTags\Plugin;
+
 /**
  * FewerTags Admin Class
  */
@@ -34,14 +36,14 @@ class Admin {
 		);
 
 		add_settings_field(
-			'joost_min_posts_count',
+			Plugin::$option_name,
 			__( 'Tags need to have', 'fewer-tags' ),
 			[ $this, 'display_setting' ],
 			'reading',
 			'fewer_tags_section'
 		);
 
-		register_setting( 'reading', 'joost_min_posts_count' );
+		register_setting( 'reading', Plugin::$option_name );
 	}
 
 	/**
@@ -55,8 +57,17 @@ class Admin {
 	 * Display the setting field in the Reading settings page.
 	 */
 	public function display_setting() {
-		echo '<input name="joost_min_posts_count" id="joost_min_posts_count" type="number" min="1" value="' . esc_attr( \FewerTags\Plugin::$min_posts_count ) . '" class="small-text" /> ';
-		esc_html_e( 'posts before being live on the site.', 'fewer-tags' );
+		?>
+		<input
+			name="<?php echo esc_attr( Plugin::$option_name ); ?>"
+			id="<?php echo esc_attr( Plugin::$option_name ); ?>"
+			type="number"
+			min="1"
+			value="<?php echo esc_attr( Plugin::$min_posts_count ); ?>"
+			class="small-text"
+		/>
+		<?php esc_html_e( 'posts before being live on the site.', 'fewer-tags' ); ?>
+		<?php
 	}
 
 	/**

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -17,7 +17,7 @@ class Plugin {
 	 *
 	 * @var string
 	 */
-	public static $option_name = 'joost_min_posts_count';
+	public static $option_name = 'fewer_tags';
 
 	/**
 	 * Default value for the minimum number of posts a tag should have to not be redirected to the homepage.

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -30,6 +30,7 @@ class Plugin {
 	 * Register plugin hooks.
 	 */
 	public function register_hooks() {
+		add_action( 'plugins_loaded', [ $this, 'migrate_option' ] );
 		add_action( 'init', [ $this, 'init' ] );
 	}
 
@@ -53,5 +54,19 @@ class Plugin {
 		}
 		$frontend = new Frontend();
 		$frontend->register_hooks();
+	}
+
+	/**
+	 * Migrate the old option to the new one.
+	 *
+	 * @since 1.4.0
+	 * @return void
+	 */
+	public function migrate_option() {
+		$old_option = get_option( 'joost_min_posts_count' );
+		if ( $old_option ) {
+			update_option( static::$option_name, $old_option );
+			delete_option( 'joost_min_posts_count' );
+		}
 	}
 }

--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -13,6 +13,13 @@ namespace FewerTags;
 class Plugin {
 
 	/**
+	 * The option name.
+	 *
+	 * @var string
+	 */
+	public static $option_name = 'joost_min_posts_count';
+
+	/**
 	 * Default value for the minimum number of posts a tag should have to not be redirected to the homepage.
 	 *
 	 * @var int
@@ -30,7 +37,7 @@ class Plugin {
 	 * Initialize the plugin and register hooks.
 	 */
 	public function init() {
-		self::$min_posts_count = (int) get_option( 'joost_min_posts_count', 10 );
+		self::$min_posts_count = (int) get_option( static::$option_name, 10 );
 
 		if ( is_admin() ) {
 			$admin = new Admin();

--- a/tests/phpunit/test-class-admin.php
+++ b/tests/phpunit/test-class-admin.php
@@ -86,7 +86,7 @@ class Admin_Test extends \WP_UnitTestCase {
 		global $wp_settings_sections, $wp_settings_fields;
 
 		$this->assertArrayHasKey( 'fewer_tags_section', $wp_settings_sections['reading'] );
-		$this->assertArrayHasKey( 'joost_min_posts_count', $wp_settings_fields['reading']['fewer_tags_section'] );
+		$this->assertArrayHasKey( Plugin::$option_name, $wp_settings_fields['reading']['fewer_tags_section'] );
 	}
 
 	/**
@@ -112,8 +112,8 @@ class Admin_Test extends \WP_UnitTestCase {
 		self::$class_instance->display_setting();
 		$output = ob_get_clean();
 
-		$this->assertStringContainsString( 'name="joost_min_posts_count"', $output );
-		$this->assertStringContainsString( 'id="joost_min_posts_count"', $output );
+		$this->assertStringContainsString( 'name="' . Plugin::$option_name . '"', $output );
+		$this->assertStringContainsString( 'id="' . Plugin::$option_name . '"', $output );
 		$this->assertStringContainsString( 'type="number"', $output );
 		$this->assertStringContainsString( 'min="1"', $output );
 		$this->assertStringContainsString( 'value="5"', $output ); // This is tied to the value of Plugin::$min_posts_count.

--- a/tests/phpunit/test-fewer-tags.php
+++ b/tests/phpunit/test-fewer-tags.php
@@ -28,7 +28,7 @@ class FewerTags_Test extends \WP_UnitTestCase {
 	public static function set_up_before_class() {
 		parent::set_up_before_class();
 
-		update_option( 'joost_min_posts_count', 10 );
+		update_option( Plugin::$option_name, 10 );
 
 		self::$class_instance = new Plugin();
 	}

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,4 +10,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	die;
 }
 
+// Backwards-compatibility for older versions of the plugin.
 delete_option( 'joost_min_posts_count' );
+
+// Delete the option.
+delete_option( 'fewer_tags' );


### PR DESCRIPTION
## Context

Changes the option name from `joost_min_posts_count` to `fewer_tags`

## Relevant technical choices:

* Added a `FewerTags\Plugin::$option_name` var for the option-name
* Wrote a simple upgrade routine, running on `plugins_loaded`

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [ ] I have added unit tests to verify the code works as intended.
* [x] I have checked that the base branch is correctly set.

Fixes #14 
