### PR TITLE
Add composer files to .distignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,3 +10,5 @@
 .phpcs.xml.dist
 phpunit.xml.dist
 README.md
+composer.json
+composer.lock


### PR DESCRIPTION
## Context
Just add `composer.json` and `composer.lock` in the `.distignore` file since right now they are included in the plugin on w.org
