### PR TITLE
Reinstate view action link for other taxonomies

### DIFF
--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -23,7 +23,7 @@ class Admin {
 		\add_action( 'admin_init', [ $this, 'register_settings' ] );
 		\add_filter( 'manage_edit-post_tag_columns', [ $this, 'add_tag_columns' ] );
 		\add_filter( 'manage_post_tag_custom_column', [ $this, 'manage_tag_columns' ], 10, 3 );
-		\add_filter( 'tag_row_actions', [ $this, 'remove_view_action' ], 10, 2 );
+		\add_filter( 'post_tag_row_actions', [ $this, 'remove_view_action' ], 10, 2 );
 	}
 
 	/**
@@ -115,12 +115,12 @@ class Admin {
 	 * Removes the "View" action link for tags that have fewer than the minimum number of posts.
 	 *
 	 * @param array    $actions An array of action links.
-	 * @param \WP_Term $term    Current WP_Term object.
+	 * @param \WP_Term $tag     Current WP_Term object.
 	 *
 	 * @return array Modified array of action links.
 	 */
-	public function remove_view_action( $actions, $term ) {
-		if ( $term->taxonomy === 'post_tag' && $term->count < \FewerTags\Plugin::$min_posts_count ) {
+	public function remove_view_action( $actions, $tag ) {
+		if ( $tag->count < \FewerTags\Plugin::$min_posts_count ) {
 			unset( $actions['view'] );
 		}
 

--- a/src/class-admin.php
+++ b/src/class-admin.php
@@ -115,12 +115,12 @@ class Admin {
 	 * Removes the "View" action link for tags that have fewer than the minimum number of posts.
 	 *
 	 * @param array    $actions An array of action links.
-	 * @param \WP_Term $tag     Current WP_Term object.
+	 * @param \WP_Term $term    Current WP_Term object.
 	 *
 	 * @return array Modified array of action links.
 	 */
-	public function remove_view_action( $actions, $tag ) {
-		if ( $tag->count < \FewerTags\Plugin::$min_posts_count ) {
+	public function remove_view_action( $actions, $term ) {
+		if ( $term->taxonomy === 'post_tag' && $term->count < \FewerTags\Plugin::$min_posts_count ) {
 			unset( $actions['view'] );
 		}
 

--- a/tests/phpunit/test-class-admin.php
+++ b/tests/phpunit/test-class-admin.php
@@ -72,7 +72,7 @@ class Admin_Test extends \WP_UnitTestCase {
 		$this->assertSame( 10, has_action( 'admin_init', [ self::$class_instance, 'register_settings' ] ) );
 		$this->assertSame( 10, has_action( 'manage_edit-post_tag_columns', [ self::$class_instance, 'add_tag_columns' ] ) );
 		$this->assertSame( 10, has_action( 'manage_post_tag_custom_column', [ self::$class_instance, 'manage_tag_columns' ] ), 10, 3 );
-		$this->assertSame( 10, has_action( 'tag_row_actions', [ self::$class_instance, 'remove_view_action' ] ), 10, 2 );
+		$this->assertSame( 10, has_action( 'post_tag_row_actions', [ self::$class_instance, 'remove_view_action' ] ), 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
## Context
<!--
What do we want to achieve with this PR? Why did we write this code?
-->

* Turns out `tag_row_actions` works for all taxonomies, `post_tag_row_actions` only works for tags, so that's what we need.

Reported in https://wordpress.org/support/topic/disables-view-option-with-custom-posts/

## Summary

This PR can be summarized in the following changelog entry:

* Reinstate `view` link for taxonomies other than `post_tag`.

## Test instructions
<!--
Please follow these guidelines when creating test instructions:
- Please provide step-by-step instructions how to reproduce the issue, if applicable.
- Write step-by-step test instructions aimed at non-tech-savvy users, even if the PR is not user-facing.
-->

1. Install & activate fewer tags
2. Create a category with 0 or 1 post in it
3. See it has no "View" link in its action links
4. Apply this patch, see the View link come back.

## Quality assurance

* [x] I have tested this code to the best of my abilities.
* [x] I have checked that the base branch is correctly set.


