### PR TITLE
Don't include the phpstan.neon.dist file in final releases

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -12,3 +12,4 @@ phpunit.xml.dist
 README.md
 composer.json
 composer.lock
+phpstan.neon.dist

--- a/.gitattributes
+++ b/.gitattributes
@@ -19,6 +19,7 @@ composer.lock export-ignore
 phpunit.xml.dist export-ignore
 /README.md export-ignore
 /tests export-ignore
+phpstan.neon.dist export-ignore
 
 #
 # Auto detect text files and perform LF normalization


### PR DESCRIPTION
## Context
I just noticed that in this last release, the `phpstan.neon.dist` file was included in the files on .org

This PR adds an exclusion in `.distignore` and `.gitattributes` for that file.